### PR TITLE
Import layout before base

### DIFF
--- a/content/Assets/Styles/index.scss
+++ b/content/Assets/Styles/index.scss
@@ -17,11 +17,11 @@
 
 @import "generic/all";
 
+@import "layout/all";
+
 @import "base/all";
 
 @import "components/all";
-
-@import "layout/all";
 
 @import "trumps/all";
    


### PR DESCRIPTION
 To ensure that base can take advantage of layout-specific variables. Fixes #60 