### PR TITLE
Use @include rem for font sizes

### DIFF
--- a/content/Assets/Styles/base/_anchor.scss
+++ b/content/Assets/Styles/base/_anchor.scss
@@ -26,7 +26,7 @@ a {
         @include rem(padding-right, $spacing-default);
         @include rem(padding-top, $spacing-small);
         
-        font-size: $font-size-h3;
+        @include rem(font-size, $font-size-h3);
     }
 }
 

--- a/content/Assets/Styles/base/_blockquote.scss
+++ b/content/Assets/Styles/base/_blockquote.scss
@@ -12,7 +12,7 @@ blockquote {
     @include text-blockquote();   
 
     @include bp-min-width($bp-tablet) {
-        font-size: $font-size-blockquote;
+        @include rem(font-size, $font-size-blockquote);
     }
 
     p {

--- a/content/Assets/Styles/components/form/_field.scss
+++ b/content/Assets/Styles/components/form/_field.scss
@@ -12,7 +12,7 @@
 
 .field__label {
     @include themify($themes) {
-        font-size: themed('fontSize.small');
+        @include rem(font-size, themed('fontSize.small'));
     }
 
     width: 100%;

--- a/content/Assets/Styles/tools/_text.scss
+++ b/content/Assets/Styles/tools/_text.scss
@@ -22,51 +22,51 @@
 @mixin text-hero() {
     @include text-heading();
 
-    font-size: $font-size-hero-mobile;
+    @include rem(font-size, $font-size-hero-mobile);
     line-height: $font-line-height-hero;
 
     @include bp-min-width($bp-desktop) {
-        font-size: $font-size-hero;
+        @include rem(font-size, $font-size-hero);
     }
 }
 
 @mixin text-h1() {
     @include text-heading();
 
-    font-size: $font-size-h1-mobile;
+    @include rem(font-size, $font-size-h1-mobile);
 
     @include bp-min-width($bp-desktop) {
-        font-size: $font-size-h1;
+        @include rem(font-size, $font-size-h1);
     }
 }
 
 @mixin text-h2() {
     @include text-heading();
 
-    font-size: $font-size-h2-mobile;
+    @include rem(font-size, $font-size-h2-mobile);
 
     @include bp-min-width($bp-desktop) {
-        font-size: $font-size-h2;
+        @include rem(font-size, $font-size-h2);
     }
 }
 
 @mixin text-h3() {
     @include text-heading();
 
-    font-size: $font-size-h3-mobile;
+    @include rem(font-size, $font-size-h3-mobile);
 
     @include bp-min-width($bp-desktop) {
-        font-size: $font-size-h3;
+        @include rem(font-size, $font-size-h3);
     }
 }
 
 @mixin text-h4() {
     @include text-heading();
 
-    font-size: $font-size-h4-mobile;
+    @include rem(font-size, $font-size-h4-mobile);
 
     @include bp-min-width($bp-desktop) {
-        font-size: $font-size-h4;
+        @include rem(font-size, $font-size-h4);
     }
 }
 

--- a/content/Assets/Styles/trumps/_text.scss
+++ b/content/Assets/Styles/trumps/_text.scss
@@ -29,35 +29,35 @@
 
     &--size {
         &-h1 { 
-            font-size: $font-size-h1-mobile;
+            @include rem(font-size, $font-size-h1-mobile);
             line-height: $font-line-height-heading;
 
             @include bp-min-width($bp-desktop) {
-                font-size: $font-size-h1;
+                @include rem(font-size, $font-size-h1);
             }
         }
         &-h2 { 
-            font-size: $font-size-h2-mobile;
+            @include rem(font-size, $font-size-h2-mobile);
             line-height: $font-line-height-heading;
 
             @include bp-min-width($bp-desktop) {
-                font-size: $font-size-h2;
+                @include rem(font-size, $font-size-h2);
             }
         }
         &-h3 { 
-            font-size: $font-size-h3-mobile;
+            @include rem(font-size, $font-size-h3-mobile);
             line-height: $font-line-height-heading;
 
             @include bp-min-width($bp-desktop) {
-                font-size: $font-size-h3;
+                @include rem(font-size, $font-size-h3);
             }
         }
         &-h4 { 
-            font-size: $font-size-h4-mobile;
+            @include rem(font-size, $font-size-h4-mobile);
             line-height: $font-line-height-heading;
 
             @include bp-min-width($bp-desktop) {
-                font-size: $font-size-h4;
+                @include rem(font-size, $font-size-h4);
             }
         }
     }


### PR DESCRIPTION
Searched for and replaced any instance of a font-size: rule and replaced it with our rem mixin, which outputs the rem value and a px backup.

The only elements not changed (html and body) are commented in the CSS already with reasons why they have to remain as percentages/em respectively.

Fixes #63 