### PR TITLE
Create default theme NuGet package

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Namespace for project containing Orchard Core website that will have reference t
 
 Name of your theme.
 
+#### -v/--version
+
+Version for you theme, will default to `0.0.1-rc1` if not specified.
+
 #### -w/--website
 
 URL for your website.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To create a new theme using the boilerplate it's quickest to use the `dotnet new
 
 Once installed successfully, run the command below, which demonstrates all the possible parameters that are available.
 
-    dotnet new orchardcore-themeboilerplate -n Example.OrchardCore.Theme -o Example.OrchardCore.Theme -au "Your Company Ltd." -d "Description for your theme" -p "Your.OrchardCore.Site" -t "Your Theme Name" -w "https://yourwebsite.co.uk"
+    dotnet new orchardcore-themeboilerplate -n Example.OrchardCore.Theme -o Example.OrchardCore.Theme -au "Your Company Ltd." -d "Description for your theme" -t "Your Theme Name" -w "https://yourwebsite.co.uk"
 
 ### Parameters
 
@@ -27,10 +27,6 @@ Author of the theme.
 #### -d/--description
 
 Short description of the theme.
-
-#### -p/--projectNamespace
-
-Namespace for project containing Orchard Core website that will have reference to theme being created.
 
 #### -t/--themeName
 

--- a/azure-pipeline-theme-stable.yml
+++ b/azure-pipeline-theme-stable.yml
@@ -1,0 +1,33 @@
+pool:
+  vmImage: 'windows-2019'
+
+variables:
+  BuildConfiguration: 'Release'
+
+steps:
+- task: CmdLine@2
+  displayName: 'Install template'
+  inputs:
+    script: 'dotnet new -i ./'
+
+- task: CmdLine@2
+  displayName: 'Create new theme via template'
+  inputs:
+    script: 'dotnet new orchardcore-themeboilerplate -n Etch.OrchardCore.DefaultTheme -o "$(Build.ArtifactStagingDirectory)/Etch.OrchardCore.DefaultTheme" -au "Etch UK Ltd." -d "Default boilerplate theme." -t "Default Theme" -w "https://etchuk.com"'
+    
+- task: DotNetCoreCLI@2
+  displayName: 'Build theme'
+  inputs:
+    workingDirectory: $(Build.ArtifactStagingDirectory)/Etch.OrchardCore.DefaultTheme
+    arguments: '-c $(BuildConfiguration)'
+
+- task: CmdLine@2
+  displayName: 'Package theme'
+  inputs:
+    script: 'dotnet pack -c $(BuildConfiguration) -o $(Build.ArtifactStagingDirectory)/drop --no-build'
+    workingDirectory: $(Build.ArtifactStagingDirectory)/Etch.OrchardCore.DefaultTheme
+
+- task: PublishPipelineArtifact@0
+  displayName: 'Publish pipeline artifact'
+  inputs:
+    targetPath: '$(Build.ArtifactStagingDirectory)/drop'

--- a/azure-pipeline-theme-stable.yml
+++ b/azure-pipeline-theme-stable.yml
@@ -13,7 +13,7 @@ steps:
 - task: CmdLine@2
   displayName: 'Create new theme via template'
   inputs:
-    script: 'dotnet new orchardcore-themeboilerplate -n Etch.OrchardCore.DefaultTheme -o "$(Build.ArtifactStagingDirectory)/Etch.OrchardCore.DefaultTheme" -au "Etch UK Ltd." -d "Default boilerplate theme." -t "Default Theme" -w "https://etchuk.com"'
+    script: 'dotnet new orchardcore-themeboilerplate -n Etch.OrchardCore.DefaultTheme -o "$(Build.ArtifactStagingDirectory)/Etch.OrchardCore.DefaultTheme" -au "Etch UK Ltd." -d "Default boilerplate theme." -t "Default Theme" -w "https://etchuk.com" -v "0.5.0-rc1"'
     
 - task: DotNetCoreCLI@2
   displayName: 'Build theme'

--- a/content/.template.config/template.json
+++ b/content/.template.config/template.json
@@ -20,11 +20,6 @@
             "defaultValue": "Theme for Orchard Core.",
             "replaces": "Theme boilerplate is our starting point for building Orchard Core themes."
         },
-        "projectNamespace": {
-            "type": "parameter",
-            "defaultValue": "Your.OrchardCore.Site",
-            "replaces": "Your.OrchardCore.Site"
-        },
         "themeName": {
             "type": "parameter",
             "defaultValue": "Orchard Core Theme",

--- a/content/.template.config/template.json
+++ b/content/.template.config/template.json
@@ -30,6 +30,11 @@
             "defaultValue": "Orchard Core Theme",
             "replaces": "Boilerplate Theme"
         },
+        "version": {
+            "type": "parameter",
+            "defaultValue": "0.0.1-rc1",
+            "replaces": "0.0.1-rc1"
+        },
         "website": {
             "type": "parameter",
             "defaultValue": "https://orchardcore.readthedocs.io/en/latest/",

--- a/content/.template.config/template.json
+++ b/content/.template.config/template.json
@@ -28,7 +28,7 @@
         "version": {
             "type": "parameter",
             "defaultValue": "0.0.1-rc1",
-            "replaces": "0.0.1-rc1"
+            "replaces": "0.5.0-rc1"
         },
         "website": {
             "type": "parameter",

--- a/content/Etch.OrchardCore.ThemeBoilerplate.csproj
+++ b/content/Etch.OrchardCore.ThemeBoilerplate.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
-    <Version>0.0.1-rc1</Version>
+    <Version>0.5.0-rc1</Version>
     <PackageId>Etch.OrchardCore.ThemeBoilerplate</PackageId>
     <Title>Boilerplate Theme</Title>
     <Authors>Etch UK</Authors>

--- a/content/Manifest.cs
+++ b/content/Manifest.cs
@@ -4,6 +4,6 @@ using OrchardCore.DisplayManagement.Manifest;
     Name = "Boilerplate Theme",
     Author = "Etch UK",
     Website = "https://etchuk.com",
-    Version = "0.0.1",
+    Version = "0.5.0-rc1",
     Description = "Theme boilerplate is our starting point for building Orchard Core themes."
 )]

--- a/content/Recipes/setup.recipe.json
+++ b/content/Recipes/setup.recipe.json
@@ -15,7 +15,6 @@
         {
             "name": "Feature",
             "enable": [
-                "Your.OrchardCore.Site",
                 "OrchardCore.Liquid",
                 "OrchardCore.Settings",
                 "OrchardCore.Contents",

--- a/content/package.json
+++ b/content/package.json
@@ -1,6 +1,6 @@
 {
     "name": "etch.orchardcore.themeboilerplate",
-    "version": "0.0.1-rc1",
+    "version": "0.5.0-rc1",
     "description": "Theme boilerplate is our starting point for building Orchard Core themes.",
     "author": "Etch UK",
     "scripts": {

--- a/content/package.json
+++ b/content/package.json
@@ -1,6 +1,6 @@
 {
     "name": "etch.orchardcore.themeboilerplate",
-    "version": "0.0.1",
+    "version": "0.0.1-rc1",
     "description": "Theme boilerplate is our starting point for building Orchard Core themes.",
     "author": "Etch UK",
     "scripts": {


### PR DESCRIPTION
Added a build pipeline that installs the theme boilerplate template, creates a new theme, builds it and then creates a package that can be uploaded to NuGet.

This can be added as a dependency to the site boilerplate, which removes the requirement for creating a new theme when creating a new site boilerplate to demonstrate creating a new Orchard Core project.