### PR TITLE
Build front-end assets before building theme

### DIFF
--- a/Etch.OrchardCore.ThemeBoilerplate.nuspec
+++ b/Etch.OrchardCore.ThemeBoilerplate.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Etch.OrchardCore.ThemeBoilerplate</id>
-    <version>0.5.0</version>
+    <version>0.5.1</version>
     <title>Etch Orchard Core Theme Boilerplate</title>
     <description>
       Creates Orchard Core theme using boilerplate.

--- a/azure-pipeline-theme-stable.yml
+++ b/azure-pipeline-theme-stable.yml
@@ -14,7 +14,13 @@ steps:
   displayName: 'Create new theme via template'
   inputs:
     script: 'dotnet new orchardcore-themeboilerplate -n Etch.OrchardCore.DefaultTheme -o "$(Build.ArtifactStagingDirectory)/Etch.OrchardCore.DefaultTheme" -au "Etch UK Ltd." -d "Default boilerplate theme." -t "Default Theme" -w "https://etchuk.com" -v "0.5.0-rc1"'
-    
+
+- task: CmdLine@2
+  displayName: 'Compile front-end assets'
+  inputs:
+    script: 'npm run build'
+    workingDirectory: $(Build.ArtifactStagingDirectory)/Etch.OrchardCore.DefaultTheme
+
 - task: DotNetCoreCLI@2
   displayName: 'Build theme'
   inputs:

--- a/content/.template.config/template.json
+++ b/content/.template.config/template.json
@@ -28,7 +28,7 @@
         "version": {
             "type": "parameter",
             "defaultValue": "0.0.1-rc1",
-            "replaces": "0.5.0-rc1"
+            "replaces": "0.5.1-rc1"
         },
         "website": {
             "type": "parameter",

--- a/content/Etch.OrchardCore.ThemeBoilerplate.csproj
+++ b/content/Etch.OrchardCore.ThemeBoilerplate.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
-    <Version>0.5.0-rc1</Version>
+    <Version>0.5.1-rc1</Version>
     <PackageId>Etch.OrchardCore.ThemeBoilerplate</PackageId>
     <Title>Boilerplate Theme</Title>
     <Authors>Etch UK</Authors>

--- a/content/Manifest.cs
+++ b/content/Manifest.cs
@@ -4,6 +4,6 @@ using OrchardCore.DisplayManagement.Manifest;
     Name = "Boilerplate Theme",
     Author = "Etch UK",
     Website = "https://etchuk.com",
-    Version = "0.5.0-rc1",
+    Version = "0.5.1-rc1",
     Description = "Theme boilerplate is our starting point for building Orchard Core themes."
 )]

--- a/content/package.json
+++ b/content/package.json
@@ -1,6 +1,6 @@
 {
     "name": "etch.orchardcore.themeboilerplate",
-    "version": "0.5.0-rc1",
+    "version": "0.5.1-rc1",
     "description": "Theme boilerplate is our starting point for building Orchard Core themes.",
     "author": "Etch UK",
     "scripts": {


### PR DESCRIPTION
When building a default theme from the theme boilerplate, in order to
fix front-end assets not loading, the front-end assets need to be built
before `dotnet build` otherwise the assets aren't included in the NuGet
package.