### PR TITLE
Add Rellax Parallax library to package.json and index.ts

### DIFF
--- a/content/Assets/Scripts/index.ts
+++ b/content/Assets/Scripts/index.ts
@@ -1,4 +1,5 @@
 import 'picturefill';
+import Rellax from 'rellax';
 
 import gallery from './components/gallery';
 import nav from './components/nav';
@@ -12,6 +13,7 @@ const init = () => {
     gallery();
     nav();
     toggleNav();
+    Rellax('.parallax');
 };
 
 const canInit = () => {

--- a/content/package.json
+++ b/content/package.json
@@ -20,6 +20,7 @@
         "@babel/preset-env": "^7.4.2",
         "@frctl/fractal": "^1.1.7",
         "@frctl/mandelbrot": "^1.2.1",
+        "@types/rellax": "^1.7.2",
         "autoprefixer": "^9.6.4",
         "babel-loader": "^8.0.5",
         "clean-webpack-plugin": "^2.0.1",
@@ -47,7 +48,8 @@
         "lg-video.js": "^1.0.0",
         "lightgallery.js": "^1.1.3",
         "normalize.css": "^8.0.1",
-        "picturefill": "^3.0.3"
+        "picturefill": "^3.0.3",
+        "rellax": "^1.10.0"
     },
     "fractal": {
         "main": "./BuildConfigs/fractal.config.js"


### PR DESCRIPTION
@bengammon asked me to add parallax to one of our client projects, and after getting it set up, Ben said this might be something useful going forward, so it would make sense to have it in our boilerplate.

This PR will add the library [Rellax](https://github.com/dixonandmoe/rellax) to the boilerplate, which is a lightweight library for managing parallax easily. We settled on using the class name `parallax` over `rellax` as their docs suggest, as its easier to know whats going on if you're not aware of Rellax.