### PR TITLE
Fixed responsive hero image issue on narrower viewports.

### DIFF
--- a/content/Assets/Styles/components/_hero.scss
+++ b/content/Assets/Styles/components/_hero.scss
@@ -38,16 +38,11 @@
 
     &__media {
         max-height: $hero-media-max-height;
-        min-width: $hero-media-min-width;
+        min-width: auto;
+        overflow: hidden;
         position: relative;
         width: 100%;
         z-index: $z-index-back;
-
-        overflow: hidden;
-
-        @include bp-min-width($bp-tablet) {
-            min-width: auto;
-        }
 
         .embed {
             margin-bottom: 0;


### PR DESCRIPTION
Fixes #134

@bengammon this change seems to fix it, but I don't really understand what the min-width or the include was supposed to be achieving in the first place, so could very well not the the right fix.