### PR TITLE
Embed ratios as modifiers

### DIFF
--- a/content/Assets/Styles/components/embed/_all.scss
+++ b/content/Assets/Styles/components/embed/_all.scss
@@ -2,4 +2,6 @@
    #EMBED
    ========================================================================== */
 
-@import "default";
+@import 'default';
+@import 'ratio-4-3';
+@import 'ratio-16-9';

--- a/content/Assets/Styles/components/embed/_default.scss
+++ b/content/Assets/Styles/components/embed/_default.scss
@@ -2,37 +2,22 @@
    #EMBED/DEFAULT
    ========================================================================== */
 
-/**
- * Embedding third party content responsibly.
- * Source: https://embedresponsively.com/
- */
-
 .embed {
     display: block;
     @include rem(margin-bottom, $spacing-default);
 }
 
-    .embed__source {
-        height: 0;
-        @include rem(margin-bottom, $spacing-default);
-        max-width: 100%;
-        overflow: hidden;
-        padding-bottom: 56.25%;
-        position: relative;
-        
-        > embed,
-        > iframe,
-        > object,
-        > video
-         {
-            height: 100%;
-            left: 0;
-            position: absolute; 
-            top: 0;
-            width: 100%;
-        }
-    }
+.embed__source {
+    @include rem(margin-bottom, $spacing-small);
 
-    .embed__caption {
-        font-style: italic;
+    > embed,
+    > iframe,
+    > object,
+    > video {
+        width: 100%;
     }
+}
+
+.embed__caption {
+    font-style: italic;
+}

--- a/content/Assets/Styles/components/embed/_ratio-16-9.scss
+++ b/content/Assets/Styles/components/embed/_ratio-16-9.scss
@@ -1,0 +1,27 @@
+/* ==========================================================================
+   #EMBED/RATIO 16:9
+   ========================================================================== */
+
+/**
+ * Embedding third party content responsively.
+ * Source: https://embedresponsively.com/
+ */
+
+.embed--ratio-16-9 {
+    .embed__source {
+        max-width: 100%;
+        overflow: hidden;
+        padding-bottom: 56.25%;
+        position: relative;
+
+        > embed,
+        > iframe,
+        > object,
+        > video {
+            height: 100%;
+            left: 0;
+            position: absolute;
+            top: 0;
+        }
+    }
+}

--- a/content/Assets/Styles/components/embed/_ratio-4-3.scss
+++ b/content/Assets/Styles/components/embed/_ratio-4-3.scss
@@ -1,0 +1,27 @@
+/* ==========================================================================
+   #EMBED/RATIO 4:3
+   ========================================================================== */
+
+/**
+ * Embedding third party content responsively.
+ * Source: https://embedresponsively.com/
+ */
+
+.embed--ratio-4-3 {
+    .embed__source {
+        max-width: 100%;
+        overflow: hidden;
+        padding-bottom: 75%;
+        position: relative;
+
+        > embed,
+        > iframe,
+        > object,
+        > video {
+            height: 100%;
+            left: 0;
+            position: absolute;
+            top: 0;
+        }
+    }
+}

--- a/content/PatternLibrary/patterns/01-Elements/embeds/embed-16-9.hbs
+++ b/content/PatternLibrary/patterns/01-Elements/embeds/embed-16-9.hbs
@@ -1,8 +1,8 @@
-<div class="embed">
+<div class="embed embed--ratio-16-9">
     <div class="embed__source">
         <iframe src="https://www.youtube.com/embed/m570b_d8vbk" frameborder="0" allow="autoplay; encrypted-media"
             allowfullscreen></iframe>
     </div>
 
-    <p class="embed__caption">Morbi mattis rhoncus felis, eget congue tortor tempor accumsan.</p>
+    <p class="embed__caption">An example of an embed with a fixed 16:9 aspect ratio.</p>
 </div>

--- a/content/PatternLibrary/patterns/01-Elements/embeds/embed-4-3.hbs
+++ b/content/PatternLibrary/patterns/01-Elements/embeds/embed-4-3.hbs
@@ -1,0 +1,8 @@
+<div class="embed embed--ratio-4-3">
+    <div class="embed__source">
+        <iframe src="https://www.youtube.com/embed/mM5_T-F1Yn4" frameborder="0" allow="autoplay; encrypted-media"
+            allowfullscreen></iframe>
+    </div>
+
+    <p class="embed__caption">An example of an embed with a fixed 4:3 aspect ratio.</p>
+</div>

--- a/content/PatternLibrary/patterns/01-Elements/embeds/embed.hbs
+++ b/content/PatternLibrary/patterns/01-Elements/embeds/embed.hbs
@@ -1,0 +1,9 @@
+<div class="embed">
+    <div class="embed__source">
+        <iframe
+            src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d10066.293341504523!2d-1.4057399!3d50.8946067!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0xa58a4d11e334d180!2sEtch%20UK%20Ltd%20(Southampton)!5e0!3m2!1sen!2suk!4v1590074574075!5m2!1sen!2suk"
+            frameborder="0" style="border:0;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe>
+    </div>
+
+    <p class="embed__caption">An example of an embed with no fixed aspect ratio</p>
+</div>


### PR DESCRIPTION
And update pattern library accordingly!

I decided just to include 16:9 and 4:3 for now as the most obvious common 2. If we encounter other common ratios we can add them in future. 

Solves https://github.com/EtchUK/Etch.OrchardCore.ThemeBoilerplate/issues/141 