### PR TITLE
Typo fixes (mobileSmall breakpoint and fontSizeH4Mobile)

### DIFF
--- a/content/Assets/Styles/variables/_breakpoints.scss
+++ b/content/Assets/Styles/variables/_breakpoints.scss
@@ -7,7 +7,7 @@
  */
 
 $mq-breakpoints: (
-    modileSmall: 320px,
+    mobileSmall: 320px,
     mobile: 375px,
     mobileLarge: 425px,
     tabletSmall: 600px,

--- a/content/Assets/Styles/variables/_typography.scss
+++ b/content/Assets/Styles/variables/_typography.scss
@@ -15,7 +15,7 @@
     --fontSizeH3: calc(var(--fontSizeBase) * 2);
     --fontSizeH3Mobile: calc(var(--fontSizeBase) * 1.5);
     --fontSizeH4: calc(var(--fontSizeBase) * 1.5);
-    --fontSizeH2Mobile: calc(var(--fontSizeBase) * 1.125);
+    --fontSizeH4Mobile: calc(var(--fontSizeBase) * 1.125);
     --fontSizeLarge: calc(var(--fontSizeBase) * 1.125);
     --fontSizeSmall: calc(var(--fontSizeBase) * 0.875);
     --fontWeightBold: 700;


### PR DESCRIPTION
Found these two typos when using the latest edition of the boilerplate, figured we'd want 'em fixed!