### PR TITLE
Heading margins

### DIFF
--- a/content/Assets/Styles/defaults/_heading.scss
+++ b/content/Assets/Styles/defaults/_heading.scss
@@ -8,7 +8,12 @@ h3,
 h4,
 h5,
 h6 {
+    margin-bottom: $spacing-text-default;
     margin-top: 0;
+
+    @include mq($from: mobileLarge) {
+        margin-bottom: $spacing-text-desktop;
+    }
 
     > a {
         text-decoration: none;

--- a/content/Assets/Styles/tools/_text.scss
+++ b/content/Assets/Styles/tools/_text.scss
@@ -13,17 +13,11 @@
 }
 
 @mixin text-heading($size) {
-    margin-bottom: $spacing-text-default;
-
     font-family: var(--fontFamilyHeading);
     font-style: normal;
     font-size: var(--fontSize#{$size}Mobile);
     font-weight: var(--fontWeightBold);
     line-height: var(--lineHeightHeading);
-
-    @include mq($from: mobileLarge) {
-        margin-bottom: $spacing-text-desktop;
-    }
 
     @include mq($from: desktop) {
         font-size: var(--fontSize#{$size});


### PR DESCRIPTION
Remove margins from text mixin and add it to default heading styles instead. 

This was an issue on a client project recently when the text-heading mixin was used on a button, which applied margin to the `:link` and `:visited` states of the button and couldn't be overridden.

This change ensures the cascade can override margin styles correctly.