### PR TITLE
Chore/typography media queries

### DIFF
--- a/content/Assets/Styles/helpers/_text.scss
+++ b/content/Assets/Styles/helpers/_text.scss
@@ -45,39 +45,23 @@
 
     &--size {
         &-h1 {
-            font-size: var(--fontSizeH1Mobile);
+            font-size: --var(fontSizeH1);
             line-height: var(--lineHeightHeading);
-
-            @include mq($from: desktop) {
-                font-size: var(--fontSizeH1);
-            }
         }
 
         &-h2 {
-            font-size: var(--fontSizeH2Mobile);
+            font-size: --var(fontSizeH2);
             line-height: var(--lineHeightHeading);
-
-            @include mq($from: desktop) {
-                font-size: var(--fontSizeH2);
-            }
         }
 
         &-h3 {
-            font-size: var(--fontSizeH3Mobile);
+            font-size: --var(fontSizeH3);
             line-height: var(--lineHeightHeading);
-
-            @include mq($from: desktop) {
-                font-size: var(--fontSizeH3);
-            }
         }
 
         &-h4 {
-            font-size: var(--fontSizeH4Mobile);
+            font-size: --var(fontSizeH4);
             line-height: var(--lineHeightHeading);
-
-            @include mq($from: desktop) {
-                font-size: var(--fontSizeH4);
-            }
         }
     }
 

--- a/content/Assets/Styles/index.scss
+++ b/content/Assets/Styles/index.scss
@@ -2,6 +2,8 @@
    #Etch.OrchardCore.ThemeBoilerplate THEME
    ========================================================================== */
 
+@import '~sass-mq';
+
 @import 'variables/all';
 
 @import 'tools/all';

--- a/content/Assets/Styles/tools/_all.scss
+++ b/content/Assets/Styles/tools/_all.scss
@@ -11,5 +11,4 @@
 @import 'grid';
 @import 'ie';
 @import 'lists';
-@import '~sass-mq';
 @import 'text';

--- a/content/Assets/Styles/tools/_text.scss
+++ b/content/Assets/Styles/tools/_text.scss
@@ -15,11 +15,7 @@
 @mixin text-heading($size) {
     font-family: var(--fontFamilyHeading);
     font-style: normal;
-    font-size: var(--fontSize#{$size}Mobile);
+    font-size: var(--fontSize#{$size});
     font-weight: var(--fontWeightBold);
     line-height: var(--lineHeightHeading);
-
-    @include mq($from: desktop) {
-        font-size: var(--fontSize#{$size});
-    }
 }

--- a/content/Assets/Styles/variables/_typography.scss
+++ b/content/Assets/Styles/variables/_typography.scss
@@ -6,16 +6,11 @@
     --fontFamilyDefault: 'Work Sans', sans-serif;
     --fontFamilyHeading: 'Manuale', sans-serif;
     --fontSizeBase: 1.6rem;
-    --fontSizeHero: calc(var(--fontSizeBase) * 4);
-    --fontSizeHeroMobile: calc(var(--fontSizeBase) * 2.25);
-    --fontSizeH1: calc(var(--fontSizeBase) * 3.75);
-    --fontSizeH1Mobile: calc(var(--fontSizeBase) * 2.25);
-    --fontSizeH2: calc(var(--fontSizeBase) * 3);
-    --fontSizeH2Mobile: calc(var(--fontSizeBase) * 2);
-    --fontSizeH3: calc(var(--fontSizeBase) * 2);
-    --fontSizeH3Mobile: calc(var(--fontSizeBase) * 1.5);
-    --fontSizeH4: calc(var(--fontSizeBase) * 1.5);
-    --fontSizeH4Mobile: calc(var(--fontSizeBase) * 1.125);
+    --fontSizeHero: calc(var(--fontSizeBase) * 2.25);
+    --fontSizeH1: calc(var(--fontSizeBase) * 2.25);
+    --fontSizeH2: calc(var(--fontSizeBase) * 2);
+    --fontSizeH3: calc(var(--fontSizeBase) * 1.5);
+    --fontSizeH4: calc(var(--fontSizeBase) * 1.125);
     --fontSizeLarge: calc(var(--fontSizeBase) * 1.125);
     --fontSizeSmall: calc(var(--fontSizeBase) * 0.875);
     --fontWeightBold: 700;
@@ -23,4 +18,12 @@
     --lineHeightDefault: 2.2rem;
     --lineHeightHeading: 1.2;
     --lineHeightHero: 1.4;
+
+    @include mq($from: desktop) {
+        --fontSizeHero: calc(var(--fontSizeBase) * 4);
+        --fontSizeH1: calc(var(--fontSizeBase) * 3.75);
+        --fontSizeH2: calc(var(--fontSizeBase) * 3);
+        --fontSizeH3: calc(var(--fontSizeBase) * 2);
+        --fontSizeH4: calc(var(--fontSizeBase) * 1.5);
+    }
 }


### PR DESCRIPTION
Addresses issue https://github.com/EtchUK/Etch.OrchardCore.ThemeBoilerplate/issues/158

`sass-mq` is now imported before variables in `index.scss` so that font size variables are updated with media queries rather than requiring a variable for each font size.

Also rebased the branch as it was last edited in November.