### PR TITLE
Allow alt text on responsive image fields by default

### DIFF
--- a/content/Recipes/Studio-ContentDefinitions.recipe.json
+++ b/content/Recipes/Studio-ContentDefinitions.recipe.json
@@ -2107,6 +2107,7 @@
                                     "Position": "1"
                                 },
                                 "ResponsiveMediaFieldSettings": {
+                                    "AllowMediaText": true,
                                     "Breakpoints": "375, 425, 600, 768, 1024, 1280, 1440, 1920, 2560",
                                     "Hint": "Image displayed as background of section.",
                                     "FallbackData": "",
@@ -2522,6 +2523,7 @@
                                     "DisplayName": "Background Image"
                                 },
                                 "ResponsiveMediaFieldSettings": {
+                                    "AllowMediaText": true,
                                     "Breakpoints": "375, 425, 600, 768, 1024, 1280, 1440, 1920, 2560",
                                     "Hint": "Image displayed as background of hero.",
                                     "Required": false
@@ -2764,6 +2766,7 @@
                                     "Position": "0"
                                 },
                                 "ResponsiveMediaFieldSettings": {
+                                    "AllowMediaText": true,
                                     "Breakpoints": "375, 425, 600, 768, 1024, 1280, 1440, 1920, 2560",
                                     "Hint": "Ensure all background images for each carousel item has the same dimensions to ensure the height of the carousel remains the same when changing the active item.",
                                     "FallbackData": "",


### PR DESCRIPTION
Although in practice these will often be blank, there will be times when no foreground content is specified and these backgrounds would benefit from contextual alt text