### PR TITLE
Hero and nav should respect text default, by default

### DIFF
--- a/content/Assets/Styles/components/hero/_variables.scss
+++ b/content/Assets/Styles/components/hero/_variables.scss
@@ -5,7 +5,7 @@
 :root {
     --heroBackgroundColor: transparent;
     --heroBodyPadding: 4.7rem;
-    --heroColor: var(--colorBlack);
+    --heroColor: var(--colorTextDefault);
     --heroColorInverted: var(--colorTextInverted);
     --heroGradientHeight: 13rem;
     --heroHeadingMarginBottom: #{$spacing-large};

--- a/content/Assets/Styles/components/nav/_variables.scss
+++ b/content/Assets/Styles/components/nav/_variables.scss
@@ -19,7 +19,7 @@ $nav-chevron-width: 1rem;
     --navAnchorPaddingDesktop: 0.5rem 1rem;
     --navBorderColor: #d7d7d7;
     --navBorderColorLight: #eaeaea;
-    --navColor: var(--colorBlack);
+    --navColor: var(--colorTextDefault);
     --navColorActive: var(--colorPrimary);
     --navColorInverted: var(--colorTextInverted);
     --navColorInvertedActive: var(--colorPrimary);


### PR DESCRIPTION
Rather than strictly black. For example, some sites will have white as the default and black as the inverted. Or another colour may be the preferred default.