### PR TITLE
Fix issue when packaging distributable that no CSS file present in new theme

### DIFF
--- a/content/BuildConfigs/webpack.config.prod.js
+++ b/content/BuildConfigs/webpack.config.prod.js
@@ -8,12 +8,17 @@ config[0].plugins.push(
     new CleanWebpackPlugin({
         cleanOnceBeforeBuildPatterns: [
             path.join(process.cwd(), 'wwwroot/content'),
-            path.join(process.cwd(), 'wwwroot/css'),
             path.join(process.cwd(), 'wwwroot/fonts'),
             path.join(process.cwd(), 'wwwroot/img'),
             path.join(process.cwd(), 'wwwroot/js'),
             path.join(process.cwd(), 'wwwroot/Theme.png'),
         ],
+    })
+);
+
+config[1].plugins.push(
+    new CleanWebpackPlugin({
+        cleanOnceBeforeBuildPatterns: [path.join(process.cwd(), 'wwwroot/css')],
     })
 );
 


### PR DESCRIPTION
Issue has been introduced since splitting the CSS/JS in to separate webpack configs. The cause of the issue is the JS config was using a plugin to delete existing artifacts, which includes the CSS file, which actually meant it was deleting the CSS artifact created in the current build. Solution was to make the CSS config responsible for cleaning it's own artifact folder.