### PR TITLE
Override `GalleryPart` to prevent clashing CSS/JS files being loaded

### DIFF
--- a/content/Views/GalleryPart.liquid
+++ b/content/Views/GalleryPart.liquid
@@ -1,0 +1,11 @@
+{% if Model.HasMediaItems %}
+    <ul class="gallery js-gallery">
+    {% for media in Model.MediaItems %}
+        <li class="gallery__item gallery__item--{{ media.TypeName | downcase | slugify }}">
+            <a href="{{ media.Url }}">
+                <img src="{{ media.Thumb }}" title="{{ media.Title }}" alt="{{ media.Title }}" />
+            </a>
+        </li>
+    {% endfor %}
+    </ul>
+{% endif %}


### PR DESCRIPTION
Issue with the light gallery was there were two instances being fired, which meant that if the theme JS file loaded second then an error would occur because the HTML would have already been updated by the JS loaded from the module.