### PR TITLE
Remove tablet min-width:auto

### DIFF
--- a/content/Assets/Styles/components/hero/_default.scss
+++ b/content/Assets/Styles/components/hero/_default.scss
@@ -71,10 +71,6 @@
         overflow: hidden;
         z-index: $z-index-back;
 
-        @include mq($from: tablet) {
-            min-width: auto;
-        }
-
         @each $width in $widths {
             .width--#{math.floor($width)} & {
                 min-height: 0;


### PR DESCRIPTION
Since the aspect ratio rewrite, this is no longer relevant and causes layout issues. 

https://trello.com/c/NBXiGvPk/243-adjust-hero-default-css