### PR TITLE
Update visually hidden class

### DIFF
--- a/content/Assets/Styles/helpers/_screen-reader.scss
+++ b/content/Assets/Styles/helpers/_screen-reader.scss
@@ -8,7 +8,7 @@
  * https://a11yproject.com/posts/how-to-hide-content/
  */
 
-.visually-hidden {
+.visually-hidden:not(:focus):not(:active) {
     height: 1px;
     overflow: hidden;
     position: absolute !important;
@@ -16,5 +16,6 @@
 
     white-space: nowrap;
 
-    clip: rect(1px, 1px, 1px, 1px);
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
 }


### PR DESCRIPTION
To match latest version of referenced article, which includes clip path inset, 0 as the clip value, and applying not: additions to the selector to ensure that tabbable elements which are visually hidden become visible when highlighted by eg. keyboard control