### PR TITLE
Override flow max-width when using constrain--full

### DIFF
--- a/content/Assets/Styles/components/flow/_default.scss
+++ b/content/Assets/Styles/components/flow/_default.scss
@@ -48,6 +48,10 @@
     .constrain--wide & {
         max-width: $content-width-wide;
     }
+
+    .constrain--full & {
+        max-width: 100%;
+    }
 }
 
 .flow__content {


### PR DESCRIPTION
See [adjacent PR](https://github.com/EtchUK/Etch.OrchardCore.Widgets/pull/80) which ensures section widths are always output, even when set to full.