### PR TITLE
Remove padding from constrain--full

### DIFF
--- a/content/Assets/Styles/helpers/_constrain.scss
+++ b/content/Assets/Styles/helpers/_constrain.scss
@@ -31,14 +31,16 @@
     max-width: $content-width-extra-thin;
 }
 
-.constrain--full {
-    max-width: none;
-}
-
 .constrain--thin {
     max-width: $content-width-thin;
 }
 
 .constrain--wide {
     max-width: $content-width-wide;
+}
+
+.constrain--full {
+    max-width: 100%;
+    padding-left: 0;
+    padding-right: 0;
 }


### PR DESCRIPTION
Now that we're outputting constrain--full, it transpires that all constrains have padding by default, which is undesirable if you're putting e.g a full width image into a constrain full. It did make me wonder whether there should be "Full (With Gutter)" and "Full (No Gutter)" as options, so you could do full width stuff but not-quite touch the sides, but in practice I think it's going to always (or almost always) want to be paddingless so let's go with this and see if it comes up.