### PR TITLE
Hero aspect ratio embed widths

### DIFF
--- a/content/Assets/Styles/components/hero/_ratio.scss
+++ b/content/Assets/Styles/components/hero/_ratio.scss
@@ -13,48 +13,88 @@
         }
 
         &-9-16 {
+            .hero__media {
+                .embed {
+                    width: 320vw;
+                }
+            }
             .hero__space {
                 padding-bottom: math.div(16, 9) * 100%;
             }
         }
 
         &-4-3 {
+            .hero__media {
+                .embed {
+                    width: 140vw;
+                }
+            }
             .hero__space {
                 padding-bottom: math.div(3, 4) * 100%;
             }
         }
 
         &-3-2 {
+            .hero__media {
+                .embed {
+                    width: 120vw;
+                }
+            }
             .hero__space {
                 padding-bottom: math.div(2, 3) * 100%;
             }
         }
 
         &-2-3 {
+            .hero__media {
+                .embed {
+                    width: 270vw;
+                }
+            }
             .hero__space {
                 padding-bottom: math.div(3, 2) * 100%;
             }
         }
 
         &-1-1 {
+            .hero__media {
+                .embed {
+                    width: 180vw;
+                }
+            }
             .hero__space {
                 padding-bottom: 100%;
             }
         }
 
         &-2-1 {
+            .hero__media {
+                .embed {
+                    width: 100vw;
+                }
+            }
             .hero__space {
                 padding-bottom: math.div(1, 2) * 100%;
             }
         }
 
         &-3-1 {
+            .hero__media {
+                .embed {
+                    width: 100vw;
+                }
+            }
             .hero__space {
                 padding-bottom: math.div(1, 3) * 100%;
             }
         }
 
         &-4-1 {
+            .hero__media {
+                .embed {
+                    width: 100vw;
+                }
+            }
             .hero__space {
                 padding-bottom: math.div(1, 4) * 100%;
             }
@@ -70,48 +110,88 @@
             }
 
             &-9-16 {
+                .hero__media {
+                    .embed {
+                        width: 320vw;
+                    }
+                }
                 .hero__space {
                     padding-bottom: math.div(16, 9) * 100%;
                 }
             }
 
             &-4-3 {
+                .hero__media {
+                    .embed {
+                        width: 140vw;
+                    }
+                }
                 .hero__space {
                     padding-bottom: math.div(3, 4) * 100%;
                 }
             }
 
             &-3-2 {
+                .hero__media {
+                    .embed {
+                        width: 120vw;
+                    }
+                }
                 .hero__space {
                     padding-bottom: math.div(2, 3) * 100%;
                 }
             }
 
             &-2-3 {
+                .hero__media {
+                    .embed {
+                        width: 270vw;
+                    }
+                }
                 .hero__space {
                     padding-bottom: math.div(3, 2) * 100%;
                 }
             }
 
             &-1-1 {
+                .hero__media {
+                    .embed {
+                        width: 180vw;
+                    }
+                }
                 .hero__space {
                     padding-bottom: 100%;
                 }
             }
 
             &-2-1 {
+                .hero__media {
+                    .embed {
+                        width: 100vw;
+                    }
+                }
                 .hero__space {
                     padding-bottom: math.div(1, 2) * 100%;
                 }
             }
 
             &-3-1 {
+                .hero__media {
+                    .embed {
+                        width: 100vw;
+                    }
+                }
                 .hero__space {
                     padding-bottom: math.div(1, 3) * 100%;
                 }
             }
 
             &-4-1 {
+                .hero__media {
+                    .embed {
+                        width: 100vw;
+                    }
+                }
                 .hero__space {
                     padding-bottom: math.div(1, 4) * 100%;
                 }
@@ -128,48 +208,88 @@
             }
 
             &-9-16 {
+                .hero__media {
+                    .embed {
+                        width: 320vw;
+                    }
+                }
                 .hero__space {
                     padding-bottom: math.div(16, 9) * 100%;
                 }
             }
 
             &-4-3 {
+                .hero__media {
+                    .embed {
+                        width: 140vw;
+                    }
+                }
                 .hero__space {
                     padding-bottom: math.div(3, 4) * 100%;
                 }
             }
 
             &-3-2 {
+                .hero__media {
+                    .embed {
+                        width: 120vw;
+                    }
+                }
                 .hero__space {
                     padding-bottom: math.div(2, 3) * 100%;
                 }
             }
 
             &-2-3 {
+                .hero__media {
+                    .embed {
+                        width: 270vw;
+                    }
+                }
                 .hero__space {
                     padding-bottom: math.div(3, 2) * 100%;
                 }
             }
 
             &-1-1 {
+                .hero__media {
+                    .embed {
+                        width: 180vw;
+                    }
+                }
                 .hero__space {
                     padding-bottom: 100%;
                 }
             }
 
             &-2-1 {
+                .hero__media {
+                    .embed {
+                        width: 100vw;
+                    }
+                }
                 .hero__space {
                     padding-bottom: math.div(1, 2) * 100%;
                 }
             }
 
             &-3-1 {
+                .hero__media {
+                    .embed {
+                        width: 100vw;
+                    }
+                }
                 .hero__space {
                     padding-bottom: math.div(1, 3) * 100%;
                 }
             }
 
             &-4-1 {
+                .hero__media {
+                    .embed {
+                        width: 100vw;
+                    }
+                }
                 .hero__space {
                     padding-bottom: math.div(1, 4) * 100%;
                 }
@@ -177,4 +297,3 @@
         }
     }
 }
-   


### PR DESCRIPTION
Add widths to embeds when aspect ratios are applied to the hero widget. This prevents gaps from appearing when the hero has a different aspect ratio to the background video.