### PR TITLE
Fixes to hero CSS

### DIFF
--- a/content/Assets/Styles/components/hero/_default.scss
+++ b/content/Assets/Styles/components/hero/_default.scss
@@ -18,6 +18,8 @@
 
     color: var(--heroColor);
 
+    overflow: hidden;
+
     &__body {
         position: absolute;
         padding: var(--heroBodyPadding) 0;
@@ -35,7 +37,7 @@
         display: block;
         margin-bottom: $spacing-large;
         color: var(--colorTextLight);
-        font-family: var(----fontFamilyHeading);
+        font-family: var(--fontFamilyHeading);
         font-weight: var(--cardMetaWeight);
         text-transform: var(--cardMetaTextTransform);
 
@@ -58,7 +60,6 @@
         display: flex;
         justify-content: center;
         left: 50%;
-        max-height: var(--heroMediaMaxHeight);
         min-height: 100%;
         min-width: 100%;
         position: absolute;

--- a/content/Assets/Styles/components/hero/_variables.scss
+++ b/content/Assets/Styles/components/hero/_variables.scss
@@ -10,7 +10,6 @@
     --heroGradientHeight: 13rem;
     --heroHeadingMarginBottom: #{$spacing-large};
     --heroHeadingTextTransform: uppercase;
-    --heroMediaMaxHeight: 90vh;
     --heroMediaMinHeight: 50rem;
     --heroPullDistance: 8rem;
     --heroSpacingAfterLarge: 9rem;


### PR DESCRIPTION
Max height no longer useful (and actually breaks the aspect ratio sizing in certain scenarios), one variable is incorrectly used, and overflow hidden is required to ensure videos don't spill out when they're scaled up to cover alternative aspect ratios (which was added in a recent PR)