### PR TITLE
Remove Gallery module enablement

### DIFF
--- a/content/Recipes/Basic-FeaturesAndSettings.recipe.json
+++ b/content/Recipes/Basic-FeaturesAndSettings.recipe.json
@@ -34,7 +34,6 @@
                 "OrchardCore.Flows",
                 "OrchardCore.Alias",
                 "Etch.OrchardCore.Fields.ResponsiveMedia",
-                "Etch.OrchardCore.Gallery",
                 "OrchardCore.Indexing",
                 "OrchardCore.Lucene",
                 "OrchardCore.Queries",

--- a/content/Recipes/Studio-FeaturesAndSettings.recipe.json
+++ b/content/Recipes/Studio-FeaturesAndSettings.recipe.json
@@ -36,7 +36,6 @@
                 "Etch.OrchardCore.Favicon",
                 "OrchardCore.Alias",
                 "Etch.OrchardCore.Fields.ResponsiveMedia",
-                "Etch.OrchardCore.Gallery",
                 "OrchardCore.Indexing",
                 "OrchardCore.Lucene",
                 "OrchardCore.Queries",


### PR DESCRIPTION
As we now include an updated Gallery via the widgets module, enabling this feature creates conflict and adds legacy functionality we no longer need.