### PR TITLE
Fix meta title not overridding page title

### DIFF
--- a/content/Views/ContentsMetadata.cshtml
+++ b/content/Views/ContentsMetadata.cshtml
@@ -1,9 +1,0 @@
-@using OrchardCore.ContentManagement
-
-@{
-    ContentItem contentItem = Model.ContentItem;
-
-    if (Model.ContentItem.Content.MetaTagsPart == null || string.IsNullOrWhiteSpace((string)Model.ContentItem.Content.MetaTagsPart.Title)) {
-        Title.AddSegment(Html.Raw(Html.Encode(contentItem.DisplayText)));
-    }
-}


### PR DESCRIPTION
Removed obsolete `ContentsMetadata` template as SEO module contains template that uses updated SEO definition.

https://github.com/EtchUK/Etch.OrchardCore.SEO/blob/main/Views/ContentsMetadata.cshtml