### PR TITLE
Fix npm build issue related to mini-css-extract-plugin

### DIFF
--- a/content/package.json
+++ b/content/package.json
@@ -29,7 +29,7 @@
         "imagemin-optipng": "^8.0.0",
         "imagemin-pngquant": "^9.0.1",
         "imagemin-svgo": "^9.0.0",
-        "mini-css-extract-plugin": "^2.2.2",
+        "mini-css-extract-plugin": "~2.4.5",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.3.6",
         "postcss-loader": "^6.1.1",


### PR DESCRIPTION
Applied workaround that's described in https://github.com/webpack-contrib/mini-css-extract-plugin/issues/896.