### PR TITLE
Add hero 100vh option

### DIFF
--- a/content/Assets/Styles/components/hero/_default.scss
+++ b/content/Assets/Styles/components/hero/_default.scss
@@ -8,13 +8,15 @@
   * 2. Vertically center the embed if it is taller than .hero__media
   */
 
-@use "sass:math";
+@use 'sass:math';
 
 .hero {
     align-items: center;
     display: flex;
     justify-content: center;
     position: relative;
+
+    background: var(--heroBackgroundColor);
 
     color: var(--heroColor);
 
@@ -67,10 +69,7 @@
         transform: translate(-50%, -50%);
         width: auto;
 
-        background: var(--heroBackgroundColor);
-
         overflow: hidden;
-        z-index: $z-index-back;
 
         @each $width in $widths {
             .width--#{math.floor($width)} & {

--- a/content/Assets/Styles/components/hero/_ratio.scss
+++ b/content/Assets/Styles/components/hero/_ratio.scss
@@ -2,7 +2,13 @@
    #HERO/RATIO
    ========================================================================== */
 
-@use "sass:math";
+@use 'sass:math';
+
+/*
+ * 1. With a 100vh hero, and a 16:9 asset, the media width should scale 
+ *    based on the viewport height, to ensure it covers. 
+ *    16/9 = 1.7777 recurring, which we round to 178%
+ */
 
 .hero {
     &--mobile-ratio {
@@ -97,6 +103,21 @@
             }
             .hero__space {
                 padding-bottom: math.div(1, 4) * 100%;
+            }
+        }
+
+        &-100vh {
+            .hero__media,
+            .hero-responsive-media--background-image {
+                .embed,
+                img {
+                    width: 178vh; /* 1 */
+                    max-width: none;
+                    min-width: 100%;
+                }
+            }
+            .hero__space {
+                padding-bottom: 100vh;
             }
         }
     }
@@ -196,6 +217,21 @@
                     padding-bottom: math.div(1, 4) * 100%;
                 }
             }
+
+            &-100vh {
+                .hero__media,
+                .hero-responsive-media--background-image {
+                    .embed,
+                    img {
+                        width: 178vh; /* 1 */
+                        max-width: none;
+                        min-width: 100%;
+                    }
+                }
+                .hero__space {
+                    padding-bottom: 100vh;
+                }
+            }
         }
     }
 
@@ -292,6 +328,21 @@
                 }
                 .hero__space {
                     padding-bottom: math.div(1, 4) * 100%;
+                }
+            }
+
+            &-100vh {
+                .hero__media,
+                .hero-responsive-media--background-image {
+                    .embed,
+                    img {
+                        width: 178vh; /* 1 */
+                        max-width: none;
+                        min-width: 100%;
+                    }
+                }
+                .hero__space {
+                    padding-bottom: 100vh;
                 }
             }
         }


### PR DESCRIPTION
An adjacent change is being made to widgets to add the 100vh option to the hero definition. Also, this changeset fixes the background behaviour here, so that it's possible to create colour-background heroes with no media required.