### PR TITLE
Prevent scrolling when mobile nav open

### DIFF
--- a/content/Assets/Styles/defaults/_body.scss
+++ b/content/Assets/Styles/defaults/_body.scss
@@ -21,4 +21,8 @@ body {
     @include text-default;
 
     overflow-x: hidden;
+
+    .is-nav-visible & {
+        overflow: hidden;
+    }
 }


### PR DESCRIPTION
This is a more sensible default, as the current way it behaves is never what we want