### PR TITLE
Change default vertical align on media and add modifiers

### DIFF
--- a/content/Assets/Styles/components/media/_alignment.scss
+++ b/content/Assets/Styles/components/media/_alignment.scss
@@ -1,0 +1,15 @@
+/* ==========================================================================
+   #MEDIA/ALIGNMENT
+   ========================================================================== */
+
+.media--align-bottom {
+    @include mq($from: tablet) {
+        align-items: flex-end;
+    }
+}
+
+.media--align-top {
+    @include mq($from: tablet) {
+        align-items: flex-start;
+    }
+}

--- a/content/Assets/Styles/components/media/_all.scss
+++ b/content/Assets/Styles/components/media/_all.scss
@@ -21,3 +21,5 @@
  */
 
 @import 'default';
+
+@import 'alignment';

--- a/content/Assets/Styles/components/media/_default.scss
+++ b/content/Assets/Styles/components/media/_default.scss
@@ -8,6 +8,7 @@
     position: relative;
 
     @include mq($from: tablet) {
+        align-items: center;
         display: flex;
     }
 


### PR DESCRIPTION
Changed the default vertical align of the media body content so it's aligned vertically center. Additionally added modifiers for when alignment needs to be top or bottom.