### PR TITLE
Add default for close button label

### DIFF
--- a/content/Recipes/Basic-ContentAndMedia.recipe.json
+++ b/content/Recipes/Basic-ContentAndMedia.recipe.json
@@ -108,6 +108,9 @@
                         },
                         "MenuToggleButtonLabel": {
                             "Text": "Menu"
+                        },
+                        "MenuCloseButtonLabel": {
+                            "Text": "Close"
                         }
                     },
                     "LayerMetadata": {

--- a/content/Recipes/Studio-ContentAndMedia.recipe.json
+++ b/content/Recipes/Studio-ContentAndMedia.recipe.json
@@ -3750,6 +3750,9 @@
                         },
                         "MenuToggleButtonLabel": {
                             "Text": "Menu"
+                        },
+                        "MenuCloseButtonLabel": {
+                            "Text": "Close"
                         }
                     },
                     "LayerMetadata": {


### PR DESCRIPTION
We always want this to be populated. This ensures it has something in it immediately upon setup rather than being something we might miss.