### PR TITLE
Fix hero gradient on image heroes

### DIFF
--- a/content/Assets/Styles/components/hero/_gradient.scss
+++ b/content/Assets/Styles/components/hero/_gradient.scss
@@ -14,6 +14,7 @@
 
             z-index: $z-index-mid;
         }
+
         &:before {
             left: 0;
             top: 0;

--- a/content/Assets/Styles/components/hero/_gradient.scss
+++ b/content/Assets/Styles/components/hero/_gradient.scss
@@ -2,34 +2,37 @@
    #HERO/GRADIENT
    ========================================================================== */
 
-.hero--with-media-gradient .hero__media {
-    &:before,
-    &:after {
-        content: ' ';
-        height: var(--heroGradientHeight);
-        position: absolute;
-        width: 100%;
+.hero--with-media-gradient {
+    .hero__media,
+    .hero-responsive-media--background-image {
+        &:before,
+        &:after {
+            content: ' ';
+            height: var(--heroGradientHeight);
+            position: absolute;
+            width: 100%;
 
-        z-index: 2;
-    }
-    &:before {
-        left: 0;
-        top: 0;
+            z-index: $z-index-mid;
+        }
+        &:before {
+            left: 0;
+            top: 0;
 
-        background: linear-gradient(
-            180deg,
-            #0b0b0b 0%,
-            rgba(11, 11, 11, 0) 100%
-        );
-    }
+            background: linear-gradient(
+                180deg,
+                rgba(0, 0, 0, var(--heroGradientMaxOpacity)) 0%,
+                rgba(0, 0, 0, 0) 100%
+            );
+        }
 
-    &:after {
-        bottom: 0;
-        left: 0;
-        background: linear-gradient(
-            180deg,
-            rgba(11, 11, 11, 0) 0%,
-            rgba(11, 11, 11, 0.5) 100%
-        );
+        &:after {
+            bottom: 0;
+            left: 0;
+            background: linear-gradient(
+                180deg,
+                rgba(0, 0, 0, 0) 0%,
+                rgba(0, 0, 0, var(--heroGradientMaxOpacity)) 100%
+            );
+        }
     }
 }

--- a/content/Assets/Styles/components/hero/_variables.scss
+++ b/content/Assets/Styles/components/hero/_variables.scss
@@ -7,7 +7,8 @@
     --heroBodyPadding: 4.7rem;
     --heroColor: var(--colorTextDefault);
     --heroColorInverted: var(--colorTextInverted);
-    --heroGradientHeight: 13rem;
+    --heroGradientHeight: 20rem;
+    --heroGradientMaxOpacity: 0.5;
     --heroHeadingMarginBottom: #{$spacing-large};
     --heroHeadingTextTransform: uppercase;
     --heroMediaMinHeight: 50rem;

--- a/content/Assets/Styles/variables/_z-index.scss
+++ b/content/Assets/Styles/variables/_z-index.scss
@@ -5,6 +5,7 @@
 $z-index-nav: 1000;
 $z-index-front: 100;
 $z-index-default: 1;
+$z-index-mid: 2;
 $z-index-nudge-forward: 3;
 $z-index-under: -1;
 $z-index-back: -100;


### PR DESCRIPTION
Was previously regressed when hero__media was replaced by automatically generated fieldname classes in the case of image backgrounds. In addition to fixing this, I also just made the default gradient more standard rather than a unique off-black and different opacities top/bottom.