### PR TITLE
Apply default alignment to image widget

### DIFF
--- a/content/Assets/Styles/components/image/_default.scss
+++ b/content/Assets/Styles/components/image/_default.scss
@@ -3,7 +3,8 @@
    ========================================================================== */
 
 .image {
-    display: inline-block; 
+    display: inline-block;
+    vertical-align: middle;
 
     &--responsive {
         display: block;


### PR DESCRIPTION
This is a more sensible default than leaving it unspecified, which currently results in a few pixels offset when putting images adjacent to text.