### PR TITLE
Remove hard set sizing for the carousel svg

### DIFF
--- a/content/Assets/Styles/components/carousel/_default.scss
+++ b/content/Assets/Styles/components/carousel/_default.scss
@@ -75,6 +75,15 @@
     }
 }
 
+.carousel__next-btn,
+.carousel__previous-btn {
+    svg {
+        display: block;
+        height: $carousel-nav-svg-height;
+        width: $carousel-nav-svg-width;
+    }
+}
+
 /**
  * 1. Position indicators above the line effect containers.
  * 2. Animation is added to the SVG so the button hit area does not also move.

--- a/content/Assets/Styles/components/carousel/_variables.scss
+++ b/content/Assets/Styles/components/carousel/_variables.scss
@@ -10,6 +10,9 @@ $carousel-indicator-size: 2rem;
 $carousel-nav-btn-x: 35px;
 $carousel-nav-btn-x-mobile: 15px;
 
+$carousel-nav-svg-height: 5rem;
+$carousel-nav-svg-width: 2.7rem;
+
 $carousel-button-hover-translate-x: -1rem;
 
 $carousel-item-translateX-desktop-medium: 17rem;


### PR DESCRIPTION
As we're now trending away from SVGs having hardset inline width/heights I have removed the hardset height and width from the svg. The height and width are now dictated using variables I have created in SCSS. 