### PR TITLE
Rely on columns helper

### DIFF
--- a/content/Assets/Styles/components/content-feed/_default.scss
+++ b/content/Assets/Styles/components/content-feed/_default.scss
@@ -57,52 +57,5 @@
         border-left: math.div($gutter, 2) solid transparent;
         border-right: math.div($gutter, 2) solid transparent;
         margin-bottom: $gutter;
-
-        .content-feed__list--two-cols & {
-            @include mq($from: desktop) {
-                flex-basis: 50%;
-            }
-            .constrain--extra-thin & {
-                @include mq($from: desktop) {
-                    flex-basis: 100%;
-                }
-            }
-        }
-
-        .content-feed__list--three-cols & {
-            @include mq($from: desktopSmall) {
-                flex-basis: 33.33%;
-            }
-
-            .constrain--extra-thin & {
-                @include mq($from: desktopSmall) {
-                    flex-basis: 100%;
-                }
-            }
-        }
-
-        .content-feed__list--four-cols & {
-            @include mq($from: tablet) {
-                flex-basis: 50%;
-            }
-            @include mq($from: desktop) {
-                flex-basis: 25%;
-            }
-
-            .constrain--thin & {
-                @include mq($from: desktop) {
-                    flex-basis: 50%;
-                }
-            }
-
-            .constrain--extra-thin & {
-                @include mq($from: tablet) {
-                    flex-basis: 100%;
-                }
-                @include mq($from: desktop) {
-                    flex-basis: 100%;
-                }
-            }
-        }
     }
 }

--- a/content/Assets/Styles/components/gallery/_default.scss
+++ b/content/Assets/Styles/components/gallery/_default.scss
@@ -17,53 +17,6 @@
         margin-bottom: var(--galleryGutter);
         position: relative;
 
-        .gallery--two-cols & {
-            @include mq($from: desktop) {
-                flex-basis: 50%;
-            }
-            .constrain--extra-thin & {
-                @include mq($from: desktop) {
-                    flex-basis: 100%;
-                }
-            }
-        }
-
-        .gallery--three-cols & {
-            @include mq($from: desktopSmall) {
-                flex-basis: 33.33%;
-            }
-
-            .constrain--extra-thin & {
-                @include mq($from: desktopSmall) {
-                    flex-basis: 100%;
-                }
-            }
-        }
-
-        .gallery--four-cols & {
-            @include mq($from: tablet) {
-                flex-basis: 50%;
-            }
-            @include mq($from: desktop) {
-                flex-basis: 25%;
-            }
-
-            .constrain--thin & {
-                @include mq($from: desktop) {
-                    flex-basis: 50%;
-                }
-            }
-
-            .constrain--extra-thin & {
-                @include mq($from: tablet) {
-                    flex-basis: 100%;
-                }
-                @include mq($from: desktop) {
-                    flex-basis: 100%;
-                }
-            }
-        }
-
         &-link {
             border-radius: var(--galleryBorderRadius);
             display: block;


### PR DESCRIPTION
Currently this CSS is effectively duplicated in multiple components, and it doesn't need to be (at least, not by default). The `helpers/_columns.scss` creates the same default behaviour. 

Content feeds already use it and are doubling up on CSS rules. An adjacent PR is incoming to Widgets to ensure that Gallery can also use the standardised helper classes.