### PR TITLE
Btn default improvements

### DIFF
--- a/content/Assets/Styles/components/button/_default.scss
+++ b/content/Assets/Styles/components/button/_default.scss
@@ -5,7 +5,7 @@
 .btn,
 .btn:link,
 .btn:visited {
-    border: var(--buttonBorderThickness) solid var(--colorPrimary);
+    border: var(--buttonBorderThickness) solid var(--colorBlack);
     border-radius: var(--buttonBorderRadius);
     display: inline-block;
     overflow: hidden;
@@ -13,10 +13,10 @@
     position: relative;
     vertical-align: middle;
 
-    background-color: var(--colorPrimary);
+    background-color: var(--colorBlack);
     outline: none;
 
-    color: var(--colorButtonLabel);
+    color: var(--colorWhite);
     font-size: var(--buttonFontSize);
     font-weight: var(--buttonFontWeight);
     line-height: var(--buttonLineHeight);
@@ -26,14 +26,26 @@
     cursor: pointer;
 
     &:hover {
-        background-color: var(--colorPrimaryActive);
-        border-color: var(--colorPrimaryActive);
+        background-color: var(--colorWhite);
+        border-color: var(--colorWhite);
+
+        color: var(--colorBlack);
     }
-}
 
-.btn:disabled {
-    background-color: var(--colorbuttonDisabled);
-    border-color: var(--colorbuttonDisabled);
+    &:disabled,
+    &[disabled] {
+        background-color: var(--buttonDisabledColor);
+        border-color: var(--buttonDisabledColor);
 
-    color: var(--colorTextDefault);
+        color: var(--buttonDisabledTextColor);
+
+        cursor: not-allowed;
+
+        &:hover {
+            background-color: var(--buttonDisabledColor);
+            border-color: var(--buttonDisabledColor);
+
+            color: var(--buttonDisabledTextColor);
+        }
+    }
 }

--- a/content/Assets/Styles/components/button/_default.scss
+++ b/content/Assets/Styles/components/button/_default.scss
@@ -34,18 +34,19 @@
 
     &:disabled,
     &[disabled] {
-        background-color: var(--buttonDisabledColor);
-        border-color: var(--buttonDisabledColor);
+        background-color: var(--colorBlack);
+        border-color: var(--colorBlack);
 
-        color: var(--buttonDisabledTextColor);
+        color: var(--colorWhite);
 
         cursor: not-allowed;
+        opacity: var(--buttonDisabledOpacity);
 
         &:hover {
-            background-color: var(--buttonDisabledColor);
-            border-color: var(--buttonDisabledColor);
+            background-color: var(--colorBlack);
+            border-color: var(--colorBlack);
 
-            color: var(--buttonDisabledTextColor);
+            color: var(--colorWhite);
         }
     }
 }

--- a/content/Assets/Styles/components/button/_primary.scss
+++ b/content/Assets/Styles/components/button/_primary.scss
@@ -14,4 +14,19 @@
         background-color: var(--colorPrimaryActive);
         border-color: var(--colorPrimaryActive);
     }
+
+    &:disabled,
+    &[disabled] {
+        background-color: var(--colorPrimary);
+        border-color: var(--colorPrimary);
+
+        color: var(--colorWhite);
+
+        &:hover {
+            background-color: var(--colorPrimary);
+            border-color: var(--colorPrimary);
+
+            color: var(--colorWhite);
+        }
+    }
 }

--- a/content/Assets/Styles/components/button/_secondary.scss
+++ b/content/Assets/Styles/components/button/_secondary.scss
@@ -14,4 +14,19 @@
         background-color: var(--colorSecondaryActive);
         border-color: var(--colorSecondaryActive);
     }
+
+    &:disabled,
+    &[disabled] {
+        background-color: var(--colorSecondary);
+        border-color: var(--colorSecondary);
+
+        color: var(--colorWhite);
+
+        &:hover {
+            background-color: var(--colorSecondary);
+            border-color: var(--colorSecondary);
+
+            color: var(--colorWhite);
+        }
+    }
 }

--- a/content/Assets/Styles/components/button/_variables.scss
+++ b/content/Assets/Styles/components/button/_variables.scss
@@ -3,22 +3,14 @@
    ========================================================================== */
 
 :root {
-    --buttonAfterHoverWipeAmount: 100%;
-    --buttonAfterOpacity: 0.1;
-    --buttonAfterTransformRotate: 100deg;
-    --buttonBorderRadius: 0;
-    --buttonBorderThickness: 0.1rem;
-    --buttonFontSize: var(--fontSizeSmall);
+    --buttonBorderRadius: var(--borderRadius);
+    --buttonBorderThickness: var(--borderWidth);
+    --buttonDisabledColor: var(--colorGrey);
+    --buttonDisabledTextColor: var(--colorGreyLight);
+    --buttonFontSize: var(--fontSizeBase);
     --buttonFontWeight: normal;
     --buttonLineHeight: var(--lineHeightDefault);
-    --buttonPaddingHorizontal: 2rem;
-    --buttonPaddingVertical: 1rem;
+    --buttonPaddingHorizontal: #{$spacing-large};
+    --buttonPaddingVertical: #{$spacing-default};
     --buttonTextTransform: none;
-
-    @include mq($from: tablet) {
-        --buttonFontSize: var(--fontSizeBase);
-        --buttonPaddingHorizontal: 3rem;
-        --buttonPaddingVertical: 1.4rem;
-        --buttonSvgMarginLeft: 1.5rem;
-    }
 }

--- a/content/Assets/Styles/components/button/_variables.scss
+++ b/content/Assets/Styles/components/button/_variables.scss
@@ -5,8 +5,7 @@
 :root {
     --buttonBorderRadius: var(--borderRadius);
     --buttonBorderThickness: var(--borderWidth);
-    --buttonDisabledColor: var(--colorGrey);
-    --buttonDisabledTextColor: var(--colorGreyLight);
+    --buttonDisabledOpacity: 0.3;
     --buttonFontSize: var(--fontSizeBase);
     --buttonFontWeight: normal;
     --buttonLineHeight: var(--lineHeightDefault);

--- a/content/Assets/Styles/components/card/_variables.scss
+++ b/content/Assets/Styles/components/card/_variables.scss
@@ -11,7 +11,7 @@ $card-overlay-media-height-tablet: 34rem;
     --cardBackgroundPattern: none;
     --cardBodyZIndex: 3; /* 1 */
     --cardBorder: var(--colorGrey);
-    --cardBorderRadius: 0;
+    --cardBorderRadius: var(--borderRadius);
     --cardBodyPadding: 2.4rem;
     --cardMediaBorder: none;
     --cardMediaMarginBottom: 0;

--- a/content/Assets/Styles/variables/_all.scss
+++ b/content/Assets/Styles/variables/_all.scss
@@ -7,6 +7,7 @@
  * https://stackoverflow.com/questions/47882/what-is-a-magic-number-and-why-is-it-bad
  */
 
+@import 'border';
 @import 'colour';
 @import 'content';
 @import 'form';

--- a/content/Assets/Styles/variables/_border.scss
+++ b/content/Assets/Styles/variables/_border.scss
@@ -1,12 +1,8 @@
 /* ==========================================================================
-   #GALLERY/VARIABLES
+   #BORDER
    ========================================================================== */
 
 :root {
-    --galleryBorderRadius: var(--borderRadius);
-    --galleryGutter: 1.5rem;
-
-    @include mq($from: mobile) {
-        --galleryGutter: 2rem;
-    }
+    --borderRadius: 0;
+    --borderWidth: 0.1rem;
 }


### PR DESCRIPTION
Removes unused variables, and sets some which are expected but not set by default.

Supports [disabled] as well as pseudo class (in case of e.g fake btns and other elements which aren't traditionally disabled), and makes the default btn black and white rather than a duplication of the primary modifier. 

As I was standardising border behaviour, I also applied the logic to cards/gallery for consistent default border radius.