### PR TITLE
Add default height to embed

### DIFF
--- a/content/Assets/Styles/components/embed/_default.scss
+++ b/content/Assets/Styles/components/embed/_default.scss
@@ -14,6 +14,7 @@
     > iframe,
     > object,
     > video {
+        height: var(--embedDefaultHeight);
         width: 100%;
     }
 }

--- a/content/Assets/Styles/components/embed/_variables.scss
+++ b/content/Assets/Styles/components/embed/_variables.scss
@@ -1,10 +1,7 @@
 /* ==========================================================================
-   #EMBED
+   #EMBED/VARIABLES
    ========================================================================== */
 
-@import 'variables';
-
-@import 'default';
-
-@import 'ratio-4-3';
-@import 'ratio-16-9';
+:root {
+    --embedDefaultHeight: 50rem;
+}


### PR DESCRIPTION
Without this, ratioless embeds are comically small by default. This applies a more sensible standard size when no ratio is provided.