### PR TITLE
Fix hero media width on desktop

### DIFF
--- a/content/Assets/Styles/components/hero/_ratio.scss
+++ b/content/Assets/Styles/components/hero/_ratio.scss
@@ -238,6 +238,12 @@
     @include mq($from: desktopSmall) {
         &--desktop-ratio {
             &-16-9 {
+                .hero__media {
+                    .embed {
+                        width: 100%;
+                    }
+                }
+
                 .hero__space {
                     padding-bottom: math.div(9, 16) * 100%;
                 }


### PR DESCRIPTION
Ensure hero 16:9 aspect ratio doesn't force embedded media wider than 100% on desktop.