### PR TITLE
Remove unused ratio logic on hero video

### DIFF
--- a/content/Assets/Styles/components/hero/_default.scss
+++ b/content/Assets/Styles/components/hero/_default.scss
@@ -89,30 +89,6 @@
             &__source {
                 margin-bottom: 0;
             }
-
-            &--ratio-16-9 {
-                width: 278%;
-
-                @include mq($from: mobile) {
-                    width: 240%;
-                }
-
-                @include mq($from: mobileLarge) {
-                    width: 215%;
-                }
-
-                @include mq($from: tabletSmall) {
-                    width: 150%;
-                }
-
-                @include mq($from: tablet) {
-                    width: 117%;
-                }
-
-                @include mq($from: desktopSmall) {
-                    width: 100%;
-                }
-            }
         }
 
         picture,


### PR DESCRIPTION
This has been superceded by more thorough (and more accurate) code in the _ratio.scss file and is no longer required, just unnecessary CSS bloat.