### PR TITLE
Improve default hero behaviour

### DIFF
--- a/content/Assets/Styles/components/hero/_default.scss
+++ b/content/Assets/Styles/components/hero/_default.scss
@@ -115,9 +115,14 @@
             }
         }
 
-        picture,
         img {
-            width: 100%;
+            height: 100%;
+            left: 50%;
+            max-width: none;
+            min-width: 100%;
+            position: absolute;
+            top: 50%;
+            transform: translate(-50%, -50%);
         }
     }
 


### PR DESCRIPTION
This change ensures that if the user only provides one image for a hero, rather than a variety of aspect ratio based sizes, we scale the one image to fit by height (ensuring coverage) and automatically lop off the sides if necessary via CSS.