### PR TITLE
New full-with-gutter option

### DIFF
--- a/content/Assets/Styles/components/alert/_default.scss
+++ b/content/Assets/Styles/components/alert/_default.scss
@@ -8,12 +8,6 @@
 
     background-color: var(--colorAlertBackground);
 
-    /* Maintain horizontal padding */
-    @include mq($from: contentWideWithGutter) {
-        padding-left: $content-gutter-small;
-        padding-right: $content-gutter-small;
-    }
-
     a {
         color: inherit;
     }

--- a/content/Assets/Styles/helpers/_constrain.scss
+++ b/content/Assets/Styles/helpers/_constrain.scss
@@ -20,11 +20,6 @@
         padding-left: $content-gutter;
         padding-right: $content-gutter;
     }
-
-    @include mq($from: contentWideWithGutter) {
-        padding-left: 0;
-        padding-right: 0;
-    }
 }
 
 .constrain--extra-thin {
@@ -37,6 +32,10 @@
 
 .constrain--wide {
     max-width: $content-width-wide;
+}
+
+.constrain--full-with-gutter {
+    max-width: 100%;
 }
 
 .constrain--full {

--- a/content/Assets/Styles/variables/_breakpoints.scss
+++ b/content/Assets/Styles/variables/_breakpoints.scss
@@ -17,5 +17,4 @@ $mq-breakpoints: (
     desktopMedium: 1440px,
     desktopLarge: 1920px,
     desktopHuge: 2200px,
-    contentWideWithGutter: 1140px,
 );

--- a/content/Assets/Styles/variables/_content.scss
+++ b/content/Assets/Styles/variables/_content.scss
@@ -15,9 +15,9 @@ $content-gutter-x-large: 10rem;
  * Content Width
  */
 
-$content-width-extra-thin: 67.6rem;
-$content-width-thin: 92rem;
-$content-width: 114rem;
-$content-width-wide: 137.2rem;
+$content-width-extra-thin: 71.6rem;
+$content-width-thin: 96rem;
+$content-width: 118rem;
+$content-width-wide: 141.2rem;
 
 $content-float-aligned-width: 40%;


### PR DESCRIPTION
I've also simplified how constrain works - essentially rather than needing to calculate whether a gutter exists, assume it always does, except for the "full without gutter" option. The default widths have increased accordingly by the gutter size so our default widths remain intact. This also means if we change the content-width-wide variable we won't be breaking the padding at certain screen sizes. 

An adjacent PR is being made for the change to the Widgets module.