### PR TITLE
Remove width-parent min height

### DIFF
--- a/content/Assets/Styles/components/hero/_default.scss
+++ b/content/Assets/Styles/components/hero/_default.scss
@@ -71,12 +71,6 @@
 
         overflow: hidden;
 
-        @each $width in $widths {
-            .width--#{math.floor($width)} & {
-                min-height: 0;
-            }
-        }
-
         .embed {
             margin-bottom: 0;
             position: absolute;


### PR DESCRIPTION
I don't know why exactly this is here, but it makes the background invisible when heroes appear side-by-side - which is definitely not desired. I think this is a holdover from a time when hero backgrounds were positioned and sized differently.