### PR TITLE
Add helper CSS class for responsive display

### DIFF
--- a/content/Assets/Styles/helpers/_all.scss
+++ b/content/Assets/Styles/helpers/_all.scss
@@ -2,17 +2,18 @@
    #TRUMPS
    ========================================================================== */
 
-@import 'alignment';
-@import 'animations/all';
-@import 'background';
-@import 'constrain';
-@import 'color';
-@import 'columns';
-@import 'display';
-@import 'gutter';
-@import 'hidden';
-@import 'inverted';
-@import 'screen-reader';
-@import 'spacing';
-@import 'text';
-@import 'width';
+@import "alignment";
+@import "animations/all";
+@import "background";
+@import "constrain";
+@import "color";
+@import "columns";
+@import "display";
+@import "gutter";
+@import "hidden";
+@import "inverted";
+@import "screen-reader";
+@import "spacing";
+@import "responsive-display";
+@import "text";
+@import "width";

--- a/content/Assets/Styles/helpers/_responsive-display.scss
+++ b/content/Assets/Styles/helpers/_responsive-display.scss
@@ -1,0 +1,21 @@
+/* ==========================================================================
+   #RESPONSIVE DISPLAY
+   ========================================================================== */
+
+.responsive-display {
+    &--large-only {
+        display: none;
+
+        @include mq($from: desktopSmall) {
+            display: block;
+        }
+    }
+
+    &--small-only {
+        display: block;
+
+        @include mq($from: desktopSmall) {
+            display: none;
+        }
+    }
+}


### PR DESCRIPTION
Classes can be used to show/hide content on small/larger screens. These classes will be utilised by a new `VisualPart` that is being added to the widgets module.