### PR TITLE
Ensure hero size is reset if 16-9 is used

### DIFF
--- a/content/Assets/Styles/components/hero/_ratio.scss
+++ b/content/Assets/Styles/components/hero/_ratio.scss
@@ -13,6 +13,11 @@
 .hero {
     &--mobile-ratio {
         &-16-9 {
+            .hero__media {
+                .embed {
+                    width: 100%;
+                }
+            }
             .hero__space {
                 padding-bottom: math.div(9, 16) * 100%;
             }
@@ -125,6 +130,11 @@
     @include mq($from: tablet) {
         &--tablet-ratio {
             &-16-9 {
+                .hero__media {
+                    .embed {
+                        width: 100%;
+                    }
+                }
                 .hero__space {
                     padding-bottom: math.div(9, 16) * 100%;
                 }
@@ -238,6 +248,11 @@
     @include mq($from: desktopSmall) {
         &--desktop-ratio {
             &-16-9 {
+                .hero__media {
+                    .embed {
+                        width: 100%;
+                    }
+                }
                 .hero__space {
                     padding-bottom: math.div(9, 16) * 100%;
                 }


### PR DESCRIPTION
Currently, without this, a tablet size can still be applied to a desktop background.