### PR TITLE
Increase default page size to 50

### DIFF
--- a/content/Recipes/Basic-FeaturesAndSettings.recipe.json
+++ b/content/Recipes/Basic-FeaturesAndSettings.recipe.json
@@ -86,6 +86,7 @@
         },
         {
             "name": "Settings",
+            "PageSize": 50,
             "HomeRoute": {},
             "LayerSettings": {
                 "Zones": ["Header", "Footer"]

--- a/content/Recipes/Studio-FeaturesAndSettings.recipe.json
+++ b/content/Recipes/Studio-FeaturesAndSettings.recipe.json
@@ -100,6 +100,7 @@
         },
         {
             "name": "Settings",
+            "PageSize": 50,
             "LayerSettings": {
                 "Zones": ["Header", "Footer"]
             },


### PR DESCRIPTION
1 - unsure why the basic recipe has so many changes, i have 0 formatting on in my visual studio (could it be invisible spaces where the email and lost password templates are? 
2 - updates the default page size to 50, I did a bit or research to see if we can use a pager toggle also, there seemed to be convo and work around it but I cant see the finished product or if it was ever implemented as the PR was closed, it merged into dev but then was closed. So I assume it was not added.