### PR TITLE
Stop lightgallery from hiding close button

### DIFF
--- a/content/Assets/Scripts/components/gallery/index.ts
+++ b/content/Assets/Scripts/components/gallery/index.ts
@@ -15,6 +15,7 @@ const lightGallery = (window as any).lightGallery;
 const instance = ($el: Element) => {
     // Handle multiple images/links
     lightGallery($el, {
+        hideBarsDelay: 0,
         selector: "a",
         videoMaxWidth: "100%",
     });

--- a/content/Assets/Scripts/components/iframeModal/index.ts
+++ b/content/Assets/Scripts/components/iframeModal/index.ts
@@ -18,6 +18,7 @@ const instance = ($el: Element) => {
         counter: false,
         download: false,
         height: "100%",
+        hideBarsDelay: 0,
         iframeMaxWidth: "100%",
         selector: "this",
         videoMaxWidth: "100%",


### PR DESCRIPTION
Currently, it hides them when your cursor is elsewhere, which is confusing (particularly on mobile)