### PR TITLE
Fix header nav btn visibility on resize

### DIFF
--- a/content/Assets/Styles/components/header/_default.scss
+++ b/content/Assets/Styles/components/header/_default.scss
@@ -138,6 +138,10 @@
 
         &--close {
             display: flex;
+
+            @include mq($from: tablet) {
+                display: none;
+            }
         }
     }
 }


### PR DESCRIPTION
Currently, if you open the mobile menu (e.g on portrait tablet) and resize (e.g rotate the tablet) the close button stays visible, incorrectly.