### PR TITLE
Pager improvements

### DIFF
--- a/content/Assets/Styles/components/pager/_default.scss
+++ b/content/Assets/Styles/components/pager/_default.scss
@@ -3,14 +3,13 @@
    ========================================================================== */
 
 .pager {
+    @extend %list-reset;
     display: flex;
     margin-bottom: 0;
     margin-top: 0;
     padding-left: 0;
 
-    list-style: none;
-
-    li:last-child {
+    li:has(a[rel~="next"]) {
         margin-left: auto;
     }
 }

--- a/content/Assets/Styles/helpers/_list-reset.scss
+++ b/content/Assets/Styles/helpers/_list-reset.scss
@@ -7,10 +7,14 @@
  * list components
  */
 
-.list-reset {
+%list-reset {
     margin-bottom: 0;
     margin-top: 0;
     padding-left: 0;
 
     list-style: none;
+}
+
+.list-reset {
+    @extend %list-reset;
 }


### PR DESCRIPTION
Resolve alignment issue (so next/prev always sit in correct location, assuming rel attributes present) and extend list-reset. List reset is extended here due to OC default pager markup being a bit trickier to override.