### PR TITLE
Disable automatic modal captioning

### DIFF
--- a/content/Assets/Scripts/components/gallery/index.ts
+++ b/content/Assets/Scripts/components/gallery/index.ts
@@ -15,6 +15,7 @@ const lightGallery = (window as any).lightGallery;
 const instance = ($el: Element) => {
     // Handle multiple images/links
     lightGallery($el, {
+        getCaptionFromTitleOrAlt: false,
         hideBarsDelay: 0,
         selector: "a",
         videoMaxWidth: "100%",

--- a/content/Assets/Scripts/components/iframeModal/index.ts
+++ b/content/Assets/Scripts/components/iframeModal/index.ts
@@ -17,6 +17,7 @@ const instance = ($el: Element) => {
     lightGallery($el, {
         counter: false,
         download: false,
+        getCaptionFromTitleOrAlt: false,
         height: "100%",
         hideBarsDelay: 0,
         iframeMaxWidth: "100%",


### PR DESCRIPTION
As this often unhelpfully populates with image alt text, even if the link you're opening is e.g a video and the thumbnail image alt is something like "Thumbnail Image"