### PR TITLE
Close menu on anchor link click

### DIFF
--- a/content/Assets/Scripts/components/closeMenuOnAnchorClick/index.ts
+++ b/content/Assets/Scripts/components/closeMenuOnAnchorClick/index.ts
@@ -1,0 +1,16 @@
+const ANCHOR_LINK_SELECTOR = 'a[href*="#"]';
+const CSS_VISIBLE = 'is-nav-visible';
+
+const closeMenuOnAnchorClick = () => {
+    const anchorLinks = document.querySelectorAll(ANCHOR_LINK_SELECTOR);
+    const $html = document.querySelector('html') as HTMLHtmlElement;
+
+    anchorLinks.forEach((link) => {
+        link.addEventListener('click', (e) => {
+            $html.classList.remove(CSS_VISIBLE);
+            return true;
+        });
+    });
+};
+
+export default closeMenuOnAnchorClick;

--- a/content/Assets/Scripts/index.ts
+++ b/content/Assets/Scripts/index.ts
@@ -1,5 +1,6 @@
 import addClassOnScroll from "./components/addClassOnScroll";
 import carousel from "./components/carousel";
+import closeMenuOnAnchorClick from "./components/closeMenuOnAnchorClick";
 import gallery from "./components/gallery";
 import iframeModal from "./components/iframeModal";
 import inViewport from "./components/inViewport";
@@ -15,6 +16,7 @@ import toggleNav from "./components/toggleNav";
 const init = () => {
     addClassOnScroll();
     carousel();
+    closeMenuOnAnchorClick();
     gallery();
     iframeModal();
     inViewport();


### PR DESCRIPTION
To ensure scrolled-to content is visible on mobile, such as when anchor link appears in primary nav, or other links that could appear in the header while the menu is open