### PR TITLE
Standardise header nav breakpoint

### DIFF
--- a/content/Assets/Styles/components/header/_default.scss
+++ b/content/Assets/Styles/components/header/_default.scss
@@ -48,7 +48,7 @@
         background-color: transparent;
         border: 0;
 
-        @include mq.mq($from: tablet) {
+        @include mq.mq($from: desktopSmall) {
             display: none;
         }
 
@@ -110,7 +110,7 @@
         border-top-style: solid;
         border-top-width: var(--headerNavPaddingTop);
 
-        @include mq.mq($from: tablet) {
+        @include mq.mq($from: desktopSmall) {
             border-top: 0;
             display: flex;
             height: auto;
@@ -141,7 +141,7 @@
         &--close {
             display: flex;
 
-            @include mq.mq($from: tablet) {
+            @include mq.mq($from: desktopSmall) {
                 display: none;
             }
         }

--- a/content/Assets/Styles/components/nav/_default.scss
+++ b/content/Assets/Styles/components/nav/_default.scss
@@ -75,7 +75,7 @@
         padding-right: var(--gutterSmall);
         padding-top: var(--navAnchorPaddingTop);
 
-        @include mq.mq($from: tablet) {
+        @include mq.mq($from: desktopSmall) {
             padding: var(--navAnchorPaddingTablet);
         }
     }
@@ -161,7 +161,7 @@
 
     background-color: var(--colorGrey);
 
-    @include mq.mq($from: tablet) {
+    @include mq.mq($from: desktopSmall) {
         position: absolute;
 
         background-color: var(--colorWhite);
@@ -175,7 +175,7 @@
         padding-left: var(--gutter);
         padding-right: var(--gutter);
 
-        @include mq.mq($from: tablet) {
+        @include mq.mq($from: desktopSmall) {
             padding: var(--navAnchorPaddingTablet);
         }
     }

--- a/content/Assets/Styles/components/nav/_primary.scss
+++ b/content/Assets/Styles/components/nav/_primary.scss
@@ -7,7 +7,7 @@
 .nav--primary {
     .nav__item .link,
     .nav__item-link--default {
-        @include mq.mq($from: tablet) {
+        @include mq.mq($from: desktopSmall) {
             padding: var(--navPrimaryAnchorPaddingDesktop);
         }
     }


### PR DESCRIPTION
Prior to this change, there's a mix of tablet and desktopSmall. desktopSmall seems the more appropriate/forgiving option to have as a default, allowing for longer menus.