### PR TITLE
TypeScript build improvements

### DIFF
--- a/content/Assets/Scripts/components/closeMenuOnAnchorClick/index.ts
+++ b/content/Assets/Scripts/components/closeMenuOnAnchorClick/index.ts
@@ -1,12 +1,12 @@
 const ANCHOR_LINK_SELECTOR = 'a[href*="#"]';
-const CSS_VISIBLE = 'is-nav-visible';
+const CSS_VISIBLE = "is-nav-visible";
 
 const closeMenuOnAnchorClick = () => {
     const anchorLinks = document.querySelectorAll(ANCHOR_LINK_SELECTOR);
-    const $html = document.querySelector('html') as HTMLHtmlElement;
+    const $html = document.querySelector("html") as HTMLHtmlElement;
 
     anchorLinks.forEach((link) => {
-        link.addEventListener('click', (e) => {
+        link.addEventListener("click", () => {
             $html.classList.remove(CSS_VISIBLE);
             return true;
         });

--- a/content/Assets/Scripts/components/iframeModal/index.ts
+++ b/content/Assets/Scripts/components/iframeModal/index.ts
@@ -27,9 +27,9 @@ const instance = ($el: Element) => {
 
     $el.addEventListener(
         "onAfterOpen",
-        (e) => {
+        () => {
             const $wrapper = document.getElementsByClassName("lg-video");
-            
+
             if ($wrapper.length === 0) {
                 return;
             }
@@ -43,9 +43,9 @@ const instance = ($el: Element) => {
 
     $el.addEventListener(
         "onCloseAfter",
-        (e) => {
+        () => {
             const $wrapper = document.getElementsByClassName("lg-video");
-            
+
             if ($wrapper.length === 0) {
                 return;
             }

--- a/content/Assets/Scripts/index.ts
+++ b/content/Assets/Scripts/index.ts
@@ -33,7 +33,7 @@ const canInit = () => {
     return regReady.test(document.readyState || "");
 };
 
-let timer: NodeJS.Timeout;
+let timer: number;
 
 const checkCanInit = () => {
     if (canInit()) {

--- a/content/package.json
+++ b/content/package.json
@@ -4,14 +4,15 @@
         "node": ">=14"
     },
     "scripts": {
-        "build": "npm i --no-audit && vite build",
+        "build": "npm i --no-audit && tsc && vite build",
         "develop": "vite",
         "install-git-hooks": "cd .. && husky install",
-        "lint": "lint-staged",
+        "lint": "lint-staged && tsc",
         "prepare": "npm run install-git-hooks",
         "start": "npm i && npm run develop"
     },
     "devDependencies": {
+        "@types/rellax": "^1.7.4",
         "@typescript-eslint/eslint-plugin": "^5.60.1",
         "eslint": "^8.43.0",
         "eslint-config-prettier": "^8.8.0",
@@ -23,6 +24,7 @@
         "stylelint": "^15.2.0",
         "stylelint-config-prettier-scss": "^1.0.0",
         "stylelint-config-recommended-scss": "^12.0.0",
+        "typescript": "^5.1.6",
         "vite": "^4.1.4",
         "vite-plugin-mkcert": "^1.13.3"
     },

--- a/content/tsconfig.json
+++ b/content/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "esModuleInterop": true,
+        "isolatedModules": true,
+        "lib": ["ESNext", "DOM", "DOM.Iterable"],
+        "module": "ESNext",
+        "moduleResolution": "Node",
+        "noEmit": true,
+        "noImplicitReturns": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "resolveJsonModule": true,
+        "skipLibCheck": true,
+        "strict": true,
+        "target": "ESNext",
+        "useDefineForClassFields": true
+    },
+    "include": ["./Assets/Scripts/**/*"]
+}


### PR DESCRIPTION
- Run `tsc` as part of build to ensure TypeScript errors are caught
- Run `tsc` as a pre-commit hook to ensure TypeScript errors are caught before commit can be completed
- Use same `tsconfig.json` as used on Etch CMS
- Fix typescript compile errors